### PR TITLE
Accept fuse mountpoint

### DIFF
--- a/fs/sdcardfs/dentry.c
+++ b/fs/sdcardfs/dentry.c
@@ -59,6 +59,12 @@ static int sdcardfs_d_revalidate(struct dentry *dentry, unsigned int flags)
 	lower_dentry = lower_path.dentry;
 	lower_cur_parent_dentry = dget_parent(lower_dentry);
 
+	// Check if we are above mountpoint
+	if (parent_lower_dentry->d_sb != lower_cur_parent_dentry->d_sb) {
+		err = 1;
+		goto out;
+	}
+
 	spin_lock(&lower_dentry->d_lock);
 	if (d_unhashed(lower_dentry)) {
 		spin_unlock(&lower_dentry->d_lock);

--- a/fs/sdcardfs/lookup.c
+++ b/fs/sdcardfs/lookup.c
@@ -176,17 +176,7 @@ int sdcardfs_interpose(struct dentry *dentry, struct super_block *sb,
 {
 	int err = 0;
 	struct inode *inode;
-	struct inode *lower_inode;
-	struct super_block *lower_sb;
-
-	lower_inode = lower_path->dentry->d_inode;
-	lower_sb = sdcardfs_lower_super(sb);
-
-	/* check that the lower file system didn't cross a mount point */
-	if (lower_inode->i_sb != lower_sb) {
-		err = -EXDEV;
-		goto out;
-	}
+	struct inode *lower_inode = lower_path->dentry->d_inode;
 
 	/*
 	 * We allocate our new inode below by calling sdcardfs_iget,


### PR DESCRIPTION
I need to mount a Fuse mountpoint in `/data/media/0` but when I try to look in /sdcard
I receive an EXDEV error

I decided to remove EXDEV return when a mountpoint is crossed (6873187)

But when linux call sdcardfs_d_revalidate on my mountpoint point like /sdcard/DCIM,
It hit this check
```        spin_lock(&lower_dentry->d_lock);
        if (d_unhashed(lower_dentry)) {
                spin_unlock(&lower_dentry->d_lock);
                d_drop(dentry);
                err = 0;
                goto out;
        }
```
So I decided to validate the cache (when a mountpoint is crossed) before this function (275b185)